### PR TITLE
Fix for issue with analzyer not correctly recognizing halanta forms due to "_" appending.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 *.py[cod]
+
+# pydev project files
+.project
+.pydevproject
+.settings
+
+sanskrit.egg-info/
+build/
+dist/
+experiments/

--- a/sanskrit/analyze.py
+++ b/sanskrit/analyze.py
@@ -54,6 +54,9 @@ class SimpleAnalyzer(Analyzer):
         for e in self.session.query(NominalEnding):
             stem_type = e.stem_type
             is_cons = (stem_type == NominalEnding.CONSONANT_STEM_TYPE)
+            if e.stem_type == "_": 
+                e.stem_type = ""
+                is_cons = True
 
             data = {
                 'name': e.name,


### PR DESCRIPTION
e.g. analyzer.analyze('diSi") would not be recognized previously. Will be correctly recognized now.

Long term may be better to fix in the sanskrit-data repo itself to not store a "_" in the endings.